### PR TITLE
Enable WORKERFS file system of emscripten to process large mp4 file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ FFmpeg.wasm Core
 
 - Eliminate thirdparty libraries not to include patent.
 - Enable WORKERFS file system of emscripten to process large mp4 file.
+- Build on single thread mode.
 
 # Original descriptions
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ FFmpeg.wasm Core
 # My custom
 
 - Eliminate thirdparty libraries not to include patent.
+- Enable WORKERFS file system of emscripten to process large mp4 file.
 
 # Original descriptions
 

--- a/build-with-docker.sh
+++ b/build-with-docker.sh
@@ -9,6 +9,6 @@ docker run \
   --rm \
   -v $PWD:/src \
   -v $PWD/wasm/cache:/emsdk_portable/.data/cache/wasm \
-  -e FFMPEG_ST=${FFMPEG_ST:-no} \
+  -e FFMPEG_ST=yes \
   emscripten/emsdk:$EM_VERSION \
   bash ./build.sh "$@"

--- a/wasm/build-scripts/build-ffmpeg.sh
+++ b/wasm/build-scripts/build-ffmpeg.sh
@@ -21,7 +21,7 @@ FLAGS=(
   -I. -I./fftools -I$BUILD_DIR/include
   -Llibavcodec -Llibavdevice -Llibavfilter -Llibavformat -Llibavresample -Llibavutil -Lharfbuzz -Llibass -Lfribidi -Llibpostproc -Llibswscale -Llibswresample -L$BUILD_DIR/lib
   -Wno-deprecated-declarations -Wno-pointer-sign -Wno-implicit-int-float-conversion -Wno-switch -Wno-parentheses -Qunused-arguments
-  -lavdevice -lavfilter -lavformat -lavcodec -lswresample -lswscale -lavutil -lpostproc -lm
+  -lworkerfs.js -lavdevice -lavfilter -lavformat -lavcodec -lswresample -lswscale -lavutil -lpostproc -lm
   #  -lharfbuzz -lfribidi -lass -lx264 -lx265 -lvpx -lwavpack -lmp3lame -lfdk-aac -lvorbis -lvorbisenc -lvorbisfile -logg -ltheora -ltheoraenc -ltheoradec -lz -lfreetype -lopus -lwebp
   fftools/ffmpeg_opt.c fftools/ffmpeg_filter.c fftools/ffmpeg_hw.c fftools/cmdutils.c fftools/ffmpeg.c
   -s USE_SDL=2                                  # use SDL2

--- a/wasm/src/post.js
+++ b/wasm/src/post.js
@@ -1,0 +1,3 @@
+Module['WORKERFS'] = WORKERFS;
+FS['mount'] = FS.mount;
+FS['unmount'] = FS.unmount;


### PR DESCRIPTION
close #2

- Enable WORKERFS file system of emscripten to process large mp4 file.
- Build on single thread mode.